### PR TITLE
Update InteractionManager key-events

### DIFF
--- a/src/opencmiss/zincwidgets/basesceneviewerwidget.py
+++ b/src/opencmiss/zincwidgets/basesceneviewerwidget.py
@@ -339,3 +339,6 @@ class BaseSceneviewerWidget(QtOpenGLWidgets.QOpenGLWidget, InteractionManager):
 
     def mouseReleaseEvent(self, event):
         self.mouse_release_event(event)
+
+    def focusOutEvent(self, event):
+        self.focus_out_event(event)

--- a/src/opencmiss/zincwidgets/handlers/abstracthandler.py
+++ b/src/opencmiss/zincwidgets/handlers/abstracthandler.py
@@ -71,5 +71,8 @@ class AbstractHandler(object):
 
         event.accept()
 
+    def focus_out_event(self, event):
+        pass
+
     def _graphics_ready(self):
         self._zinc_sceneviewer = self._scene_viewer.get_zinc_sceneviewer()

--- a/src/opencmiss/zincwidgets/handlers/interactionmanager.py
+++ b/src/opencmiss/zincwidgets/handlers/interactionmanager.py
@@ -36,25 +36,27 @@ class InteractionManager(object):
     def set_fallback_handler(self, fallback_handler):
         self._fallback_handler = fallback_handler
 
-    def activate_handler(self, handler):
+    def _activate_handler(self, handler):
         self._active_handler.leave()
         self._active_handler = handler
         self._active_handler.enter()
 
     def key_press_event(self, event):
-        if event.modifiers() in self._key_code_handler_map and not event.isAutoRepeat():
+        if event.key() in self._key_code_handler_map and not event.isAutoRepeat():
             event.accept()
-            self.activate_handler(self._key_code_handler_map[event.modifiers()])
+            self._activate_handler(self._key_code_handler_map[event.key()])
         else:
             event.ignore()
 
     def key_release_event(self, event):
-        if event.modifiers() in self._key_code_handler_map and not event.isAutoRepeat():
-            event.accept()
-            self.activate_handler(self._key_code_handler_map[event.modifiers()])
+        if event.key() in self._key_code_handler_map and not event.isAutoRepeat():
+            if self._key_code_handler_map[event.key()] == self._active_handler:
+                event.accept()
+                self._activate_handler(self._fallback_handler)
+            else:
+                event.ignore()
         else:
-            event.accept()
-            self.activate_handler(self._fallback_handler)
+            event.ignore()
 
     def mouse_enter_event(self, event):
         if self._active_handler is not None:
@@ -75,3 +77,6 @@ class InteractionManager(object):
     def mouse_move_event(self, event):
         if self._active_handler is not None:
             self._active_handler.mouse_move_event(event)
+
+    def focus_out_event(self, event):
+        self._activate_handler(self._fallback_handler)

--- a/src/opencmiss/zincwidgets/handlers/interactionmanager.py
+++ b/src/opencmiss/zincwidgets/handlers/interactionmanager.py
@@ -36,23 +36,25 @@ class InteractionManager(object):
     def set_fallback_handler(self, fallback_handler):
         self._fallback_handler = fallback_handler
 
+    def activate_handler(self, handler):
+        self._active_handler.leave()
+        self._active_handler = handler
+        self._active_handler.enter()
+
     def key_press_event(self, event):
-        if event.key() in self._key_code_handler_map and not event.isAutoRepeat():
+        if event.modifiers() in self._key_code_handler_map and not event.isAutoRepeat():
             event.accept()
-            self._active_handler.leave()
-            self._active_handler = self._key_code_handler_map[event.key()]
-            self._active_handler.enter()
+            self.activate_handler(self._key_code_handler_map[event.modifiers()])
         else:
             event.ignore()
 
     def key_release_event(self, event):
-        if event.key() in self._key_code_handler_map and not event.isAutoRepeat():
+        if event.modifiers() in self._key_code_handler_map and not event.isAutoRepeat():
             event.accept()
-            self._active_handler.leave()
-            self._active_handler = self._fallback_handler
-            self._active_handler.enter()
+            self.activate_handler(self._key_code_handler_map[event.modifiers()])
         else:
-            event.ignore()
+            event.accept()
+            self.activate_handler(self._fallback_handler)
 
     def mouse_enter_event(self, event):
         if self._active_handler is not None:


### PR DESCRIPTION
This commit updates the InteractionManager key_press_event and key_release_event methods.

Both methods have been corrected to use event.modifiers() instead of event.key() - to correspond with the new PySide6 KeyboardModifier constants.

The key_release_event method has been modified slightly so that the active handler is set to the handler corresponding with the current event modifiers - or set to the fallback handler if there is no handler matching those modifiers or if there are no modifiers.