### PR TITLE
Add intersection selection mode

### DIFF
--- a/src/cmlibs/widgets/definitions.py
+++ b/src/cmlibs/widgets/definitions.py
@@ -37,6 +37,7 @@ class SelectionMode(object):
     NONE = -1
     EXCLUSIVE = 0
     ADDITIVE = 1
+    INTERSECTION = 2
 
 
 class GraphicsSelectionMode(object):


### PR DESCRIPTION
This PR adds an intersection selection mode to the scene selection handler. This mode selects graphics picked by the scene picker only if they were already selected.